### PR TITLE
Fix GitHub Actions permissions for post conversion workflow

### DIFF
--- a/.github/workflows/convert-posts.yml
+++ b/.github/workflows/convert-posts.yml
@@ -7,6 +7,9 @@ on:
       - 'posts/*.md'
   workflow_dispatch: # Allow manual triggers
 
+permissions:
+  contents: write
+
 jobs:
   convert-posts:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Add contents: write permission to allow the workflow to push converted JSON files back to the repository.

🤖 Generated with [Claude Code](https://claude.ai/code)